### PR TITLE
fix empty input in ABI

### DIFF
--- a/dapp/src/services/ABI.js
+++ b/dapp/src/services/ABI.js
@@ -31,7 +31,10 @@
             continue;
           }
           console.log('lul');
-          var types = abi[i].inputs.map((x) => x.type);
+          var types = [];
+          if (abi[i].inputs.length >0 ) {
+            var types = abi[i].inputs.map((x) => x.type);
+          }
           var bytes = Web3Service.tronWeb.utils.ethersUtils.toUtf8Bytes(
             abi[i].name + '(' + types.join(',') + ')'
           );


### PR DESCRIPTION
Fixes transaction display failure when contract ABI contains a function without input arguments